### PR TITLE
docs: update link to commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,4 +86,4 @@ Once again, thank you for joining our journey and good luck contributing :pray:
 [submit-pr]: #submitting-a-pull-request
 [cla]: https://cla-assistant.io/dailydotdev/daily
 [style]: https://github.com/airbnb/javascript
-[commit]: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines
+[commit]: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


### PR DESCRIPTION
The present link does not navigate to the Commit Message Format header in the Angular repository's CONTRIBUTING.md. It is assumed that that was the intended purpose of adding the characters starting with '#' after the file name, in the link. Possibly the header at one point read 'Commit Message Guidelines' and now reads 'Commit Message Format'.

There are two alternatives: `#-commit-message-format` or `#commit`. I prefer the latter because:
- it is what the authors of the CONTRIBUTING.md file have used in the introduction of the doc
- it's future-proof: the header could change to another set of words but is more unlikely that the header will not start with the word 'commit'