### PR TITLE
docs: correct minor grammatical errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please take your time to read and follow our [Code of Conduct][coc].
 ## Where to Contribute?
 
 Daily is made out of several repositories, it helps us keep the different services decoupled and deliver quickly new features.
-A full list of these repositories can be found [here][projects] with short explanation about each one.
+A full list of these repositories can be found [here][projects] with a short explanation about each one.
 If you are still not sure where is the right place to contribute, ask here by [submitting an issue][submit-issue].
 
 
@@ -25,16 +25,16 @@ If you are really into it, [submit a Pull Request][submit-pr] with your fix, we 
 
 ## Documentation Never Ends
 
-When it comes to documentation there is also a room for improvement. Together we can make sure everything is up-to date and nothing is missing.
+When it comes to documentation there is also room for improvement. Together we can make sure everything is up-to-date and nothing is missing.
 You can feel free to [submit a Pull Request][submit-pr] with your documentation changes or even just [submit an issue][submit-issue].
 
 
 ## Have a Great Idea?
 
-Feel like you know what feature is missing, share you thoughts with us by [submitting an issue][submit-issue].
+Feel like you know what feature is missing, share your thoughts with us by [submitting an issue][submit-issue].
 Do you Want to make sure your feature is implemented? submit an issue with your implementation proposal.
 This will allow us to prevent duplication of work, discuss the details of the implementation and even provide design if necessary.
-Discussing about your proposal will make sure that your work will be accepted into the project.
+Discussing your proposal will make sure that your work will be accepted into the project.
 
 
 ## Contribution Guideline
@@ -50,14 +50,14 @@ Please provide as many details as possible so we can act as soon as possible.
 Before submitting a pull request consider the following guidelines:
 
 1. To prevent duplication of work, please search for existing PR (open or closed) that relates to yours.
-1. Make sure there is an issue describing your submission, whether it is a bug fix or a feature. Discussing the issue up front will make the review process much faster.
+1. Make sure there is an issue describing your submission, whether it is a bug fix or a feature. Discussing the issue upfront will make the review process much faster.
 1. Please sign our [Contributor License Agreement (CLA)][cla]. Unfortunately, we cannot accept any contribution without this. Make sure you sign and contribute with the same GitHub account.
 1. Make sure your pull request is addressing only a single concern.
  
 How to submit a pull request?
 
 1. Fork the relevant repository.
-1. Checkout a topic branch for your submission.
+1. Check out a topic branch for your submission.
 1. Apply your work there, it's fine to have multiple commits. We will make sure to squash it before merging.
 1. Make sure to add appropriate tests which cover your work.
 1. Follow our [Coding Rules](#coding-rules).
@@ -69,12 +69,12 @@ Once everything is done, your work will be live and available to all Daily users
 
 ## Coding Rules
 
-Each repository has its own coding rules and formatters to automatically enforce it when running the tests.
-As a general rule of thumb we use  [Airbnb JavaScript style guide][style] for most JavaScript projects.
+Each repository has its own coding rules and formatters to automatically enforce them when running the tests.
+As a general rule of thumb, we use  [Airbnb JavaScript style guide][style] for most JavaScript projects.
 
 ### Commit Messages
 
-We follow [Angular's commit message guidlines][commit]. This leads to more readable messages and automatic change log generation.
+We follow [Angular's commit message guidelines][commit]. This leads to more readable messages and automatic changelog generation.
 
 
 Once again, thank you for joining our journey and good luck contributing :pray:


### PR DESCRIPTION
It's common to have grammatical mistakes in a written piece. At first, I just noted the misspelling of guidelines under the 'Commit Messages' header hence the initial decision to submit a PR. However, running the text via a writing assistant I noticed several more. (I ignored some though) Using writing assistants like Grammarly could help in future to catch such grammatical mistakes early.